### PR TITLE
Fix home page routing issue in development

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,10 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
-export default defineConfig({
-  base: "/lyrical-libations/", // <-- Use your repo name here
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? "/lyrical-libations/" : "/", // Use repo name only for production build
   plugins: [
     react(), 
     tailwindcss()
   ],
-})
+}))


### PR DESCRIPTION
The static base path in vite.config.ts was causing the home route to not load properly in local development. Updated the config to use conditional base path - empty string for dev and repo name for production builds.

This ensures:
- Local development works correctly at http://localhost:xxxx/
- GitHub Pages deployment still works with /lyrical-libations/ base path

🤖 Generated with [Claude Code](https://claude.ai/code)