### PR TITLE
Fix: Make Home.tsx the default page on root URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import logo from "./assets/logo.png";
 import { routes } from "./routes/routes";
 import EditionPage from "./pages/Edition";
 import ScrollToTop from "./components/ScrollToTop";
+import Home from "./pages/Home";
 
 export default function App() {
   return (
@@ -35,8 +36,12 @@ export default function App() {
           <div className="max-w-7xl mx-auto">
             <ScrollToTop />
             <Routes>
-              {/* Static routes */}
-              {routes.map(({ href, element }) => (
+              {/* Explicit home route */}
+              <Route index element={<Home />} />
+              <Route path="/" element={<Home />} />
+              
+              {/* Other static routes (excluding home) */}
+              {routes.filter(({ href }) => href !== "/").map(({ href, element }) => (
                 <Route key={href} path={href} element={element} />
               ))}
 


### PR DESCRIPTION
Added explicit index route and root path route to ensure Home component loads when accessing the base URL. Previously, the root route was being handled through the routes array mapping but wasn't properly configured as the default/index route.

Changes:
- Added explicit `<Route index element={<Home />} />` for index route
- Added explicit `<Route path="/" element={<Home />} />` for root path
- Filtered out "/" from routes array to avoid duplication
- Imported Home component directly in App.tsx

This ensures Home.tsx loads immediately when users visit the root URL.

🤖 Generated with [Claude Code](https://claude.ai/code)