### PR TITLE
Fix Vercel deployment by removing incorrect base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,8 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
-export default defineConfig(({ command }) => ({
-  base: command === 'build' ? "/lyrical-libations/" : "/", // Use repo name only for production build
+export default defineConfig(() => ({
+  base: "/", // Use root path for Vercel deployment
   plugins: [
     react(), 
     tailwindcss()


### PR DESCRIPTION
The vite.config.ts was configured with base: "/lyrical-libations/" for GitHub Pages deployment, which causes asset loading issues on Vercel. Changed to use root path "/" for proper Vercel deployment.

This fixes the blank page issue where JS/CSS assets were not loading due to incorrect paths (/lyrical-libations/assets/ instead of /assets/).

🤖 Generated with [Claude Code](https://claude.ai/code)