### PR TITLE
Add Google Search Console verification file

### DIFF
--- a/public/googleab9dc5fcfd9a7abf.html
+++ b/public/googleab9dc5fcfd9a7abf.html
@@ -1,0 +1,1 @@
+google-site-verification: googleab9dc5fcfd9a7abf.html


### PR DESCRIPTION
## Summary
- Places `googleab9dc5fcfd9a7abf.html` in `public/` so Vite/Vercel serves it at the site root (`https://www.lyricallibations.com/googleab9dc5fcfd9a7abf.html`), which is where Google Search Console looks to verify domain ownership.
- The file was previously at the repo root, where it wouldn't be served — Vite only exposes `public/` contents at `/`.

## Test plan
- [ ] After deploy, fetch `https://www.lyricallibations.com/googleab9dc5fcfd9a7abf.html` and confirm it returns the one-line verification content (not the SPA `index.html`).
- [ ] In Google Search Console, click **Verify** on the property and confirm ownership is recognized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)